### PR TITLE
[Feature] 공통 - 네트워크 요청 모듈 생성

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		37AC3105284930E6003C3FA2 /* SignUpInfomationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AC3103284930E6003C3FA2 /* SignUpInfomationViewController.swift */; };
 		37AC3106284930E6003C3FA2 /* SignUpInfomationReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AC3104284930E6003C3FA2 /* SignUpInfomationReactor.swift */; };
 		37AC310828493367003C3FA2 /* ContourView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AC310728493367003C3FA2 /* ContourView.swift */; };
+		37C14516284DC90900D11CC3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C14515284DC90900D11CC3 /* HTTPMethod.swift */; };
+		37C14518284DC94A00D11CC3 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C14517284DC94A00D11CC3 /* NetworkError.swift */; };
 		37C3F4ED284BF4380006CB02 /* KeychainProvidable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4EC284BF4380006CB02 /* KeychainProvidable.swift */; };
 		37C3F4EF284BF4450006CB02 /* KeychainProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4EE284BF4450006CB02 /* KeychainProvider.swift */; };
 		37C3F4F8284C70E40006CB02 /* KeychainQueryRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4F7284C70E40006CB02 /* KeychainQueryRequestable.swift */; };
@@ -131,6 +133,8 @@
 		37AC3103284930E6003C3FA2 /* SignUpInfomationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInfomationViewController.swift; sourceTree = "<group>"; };
 		37AC3104284930E6003C3FA2 /* SignUpInfomationReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInfomationReactor.swift; sourceTree = "<group>"; };
 		37AC310728493367003C3FA2 /* ContourView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContourView.swift; sourceTree = "<group>"; };
+		37C14515284DC90900D11CC3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		37C14517284DC94A00D11CC3 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		37C3F4EC284BF4380006CB02 /* KeychainProvidable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProvidable.swift; sourceTree = "<group>"; };
 		37C3F4EE284BF4450006CB02 /* KeychainProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProvider.swift; sourceTree = "<group>"; };
 		37C3F4F7284C70E40006CB02 /* KeychainQueryRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainQueryRequestable.swift; sourceTree = "<group>"; };
@@ -173,6 +177,7 @@
 		376006C3284899FA00B27015 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				37C14512284DC84A00D11CC3 /* Network */,
 				37C3F4EB284BF4020006CB02 /* Keychain */,
 				376006C62848A14300B27015 /* RegularExpression */,
 			);
@@ -437,6 +442,31 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		37C14512284DC84A00D11CC3 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				37C14514284DC86300D11CC3 /* HTTPMethod */,
+				37C14513284DC85100D11CC3 /* NetworkError */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		37C14513284DC85100D11CC3 /* NetworkError */ = {
+			isa = PBXGroup;
+			children = (
+				37C14517284DC94A00D11CC3 /* NetworkError.swift */,
+			);
+			path = NetworkError;
+			sourceTree = "<group>";
+		};
+		37C14514284DC86300D11CC3 /* HTTPMethod */ = {
+			isa = PBXGroup;
+			children = (
+				37C14515284DC90900D11CC3 /* HTTPMethod.swift */,
+			);
+			path = HTTPMethod;
+			sourceTree = "<group>";
+		};
 		37C3F4EB284BF4020006CB02 /* Keychain */ = {
 			isa = PBXGroup;
 			children = (
@@ -644,6 +674,7 @@
 				378F348F281DC0770063CE4F /* ProfileCoordinator.swift in Sources */,
 				376006C82848A16400B27015 /* RegularExpressionValidatable.swift in Sources */,
 				37C3F4F8284C70E40006CB02 /* KeychainQueryRequestable.swift in Sources */,
+				37C14516284DC90900D11CC3 /* HTTPMethod.swift in Sources */,
 				37C3F4FA284C71030006CB02 /* KeychainQueryRequester.swift in Sources */,
 				378F347F281DBE070063CE4F /* GatherListReactor.swift in Sources */,
 				37605DF62839FB4100394929 /* RxASAuthorizationControllerDelegateProxy.swift in Sources */,
@@ -667,6 +698,7 @@
 				378F347A281DBDF10063CE4F /* LoginViewController.swift in Sources */,
 				37912C67281445AC0087B95E /* SceneDelegate.swift in Sources */,
 				37AC3106284930E6003C3FA2 /* SignUpInfomationReactor.swift in Sources */,
+				37C14518284DC94A00D11CC3 /* NetworkError.swift in Sources */,
 				37C3F4EF284BF4450006CB02 /* KeychainProvider.swift in Sources */,
 				377370842841BE1000D5CCB6 /* UIButton+Rx.swift in Sources */,
 			);

--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		37AC310828493367003C3FA2 /* ContourView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AC310728493367003C3FA2 /* ContourView.swift */; };
 		37C14516284DC90900D11CC3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C14515284DC90900D11CC3 /* HTTPMethod.swift */; };
 		37C14518284DC94A00D11CC3 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C14517284DC94A00D11CC3 /* NetworkError.swift */; };
+		37C1451B284E06E400D11CC3 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C1451A284E06E400D11CC3 /* NetworkManager.swift */; };
+		37C1451D284F9D6500D11CC3 /* NetworkManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C1451C284F9D6500D11CC3 /* NetworkManageable.swift */; };
 		37C3F4ED284BF4380006CB02 /* KeychainProvidable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4EC284BF4380006CB02 /* KeychainProvidable.swift */; };
 		37C3F4EF284BF4450006CB02 /* KeychainProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4EE284BF4450006CB02 /* KeychainProvider.swift */; };
 		37C3F4F8284C70E40006CB02 /* KeychainQueryRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4F7284C70E40006CB02 /* KeychainQueryRequestable.swift */; };
@@ -135,6 +137,8 @@
 		37AC310728493367003C3FA2 /* ContourView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContourView.swift; sourceTree = "<group>"; };
 		37C14515284DC90900D11CC3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		37C14517284DC94A00D11CC3 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		37C1451A284E06E400D11CC3 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		37C1451C284F9D6500D11CC3 /* NetworkManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManageable.swift; sourceTree = "<group>"; };
 		37C3F4EC284BF4380006CB02 /* KeychainProvidable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProvidable.swift; sourceTree = "<group>"; };
 		37C3F4EE284BF4450006CB02 /* KeychainProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProvider.swift; sourceTree = "<group>"; };
 		37C3F4F7284C70E40006CB02 /* KeychainQueryRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainQueryRequestable.swift; sourceTree = "<group>"; };
@@ -445,6 +449,7 @@
 		37C14512284DC84A00D11CC3 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				37C14519284DF23400D11CC3 /* Network */,
 				37C14514284DC86300D11CC3 /* HTTPMethod */,
 				37C14513284DC85100D11CC3 /* NetworkError */,
 			);
@@ -465,6 +470,15 @@
 				37C14515284DC90900D11CC3 /* HTTPMethod.swift */,
 			);
 			path = HTTPMethod;
+			sourceTree = "<group>";
+		};
+		37C14519284DF23400D11CC3 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				37C1451A284E06E400D11CC3 /* NetworkManager.swift */,
+				37C1451C284F9D6500D11CC3 /* NetworkManageable.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		37C3F4EB284BF4020006CB02 /* Keychain */ = {
@@ -683,6 +697,7 @@
 				376006C528489A2B00B27015 /* RegularExpressionValidator.swift in Sources */,
 				3773708C2841DE6D00D5CCB6 /* UserAuthentification.swift in Sources */,
 				37605DF92839FDB300394929 /* ASAuthorizationController+Rx.swift in Sources */,
+				37C1451B284E06E400D11CC3 /* NetworkManager.swift in Sources */,
 				37912CA2281449610087B95E /* SceneCoordinator.swift in Sources */,
 				37605E08283C179A00394929 /* LoginCoordinator.swift in Sources */,
 				37453D7E281DAE0900423CF0 /* BaseViewController.swift in Sources */,
@@ -697,6 +712,7 @@
 				37AC3105284930E6003C3FA2 /* SignUpInfomationViewController.swift in Sources */,
 				378F347A281DBDF10063CE4F /* LoginViewController.swift in Sources */,
 				37912C67281445AC0087B95E /* SceneDelegate.swift in Sources */,
+				37C1451D284F9D6500D11CC3 /* NetworkManageable.swift in Sources */,
 				37AC3106284930E6003C3FA2 /* SignUpInfomationReactor.swift in Sources */,
 				37C14518284DC94A00D11CC3 /* NetworkError.swift in Sources */,
 				37C3F4EF284BF4450006CB02 /* KeychainProvider.swift in Sources */,

--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -28,6 +28,10 @@
 		37605E08283C179A00394929 /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37605E07283C179A00394929 /* LoginCoordinator.swift */; };
 		37605E0A283C23FC00394929 /* SignUpAgreementCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37605E09283C23FC00394929 /* SignUpAgreementCoordinator.swift */; };
 		37605E11283C56B900394929 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 37605E10283C56B900394929 /* RxGesture */; };
+		37654FA8284FBA3600090C3F /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 37654FA7284FBA3600090C3F /* RxBlocking */; };
+		37654FAA284FBA3600090C3F /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 37654FA9284FBA3600090C3F /* RxRelay */; };
+		37654FAC284FBA3600090C3F /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 37654FAB284FBA3600090C3F /* RxSwift */; };
+		37654FAE284FBA3600090C3F /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = 37654FAD284FBA3600090C3F /* RxTest */; };
 		3770FFEE283112E8001960A0 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3770FFED283112E8001960A0 /* RxCocoa */; };
 		3770FFF0283112E8001960A0 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3770FFEF283112E8001960A0 /* RxSwift */; };
 		3770FFF3283112F4001960A0 /* ReactorKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3770FFF2283112F4001960A0 /* ReactorKit */; };
@@ -64,6 +68,8 @@
 		37C14518284DC94A00D11CC3 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C14517284DC94A00D11CC3 /* NetworkError.swift */; };
 		37C1451B284E06E400D11CC3 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C1451A284E06E400D11CC3 /* NetworkManager.swift */; };
 		37C1451D284F9D6500D11CC3 /* NetworkManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C1451C284F9D6500D11CC3 /* NetworkManageable.swift */; };
+		37C14522284F9EFB00D11CC3 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C14521284F9EFB00D11CC3 /* MockURLProtocol.swift */; };
+		37C14524284FA17800D11CC3 /* NetworkManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C14523284FA17800D11CC3 /* NetworkManagerTests.swift */; };
 		37C3F4ED284BF4380006CB02 /* KeychainProvidable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4EC284BF4380006CB02 /* KeychainProvidable.swift */; };
 		37C3F4EF284BF4450006CB02 /* KeychainProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4EE284BF4450006CB02 /* KeychainProvider.swift */; };
 		37C3F4F8284C70E40006CB02 /* KeychainQueryRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4F7284C70E40006CB02 /* KeychainQueryRequestable.swift */; };
@@ -139,6 +145,8 @@
 		37C14517284DC94A00D11CC3 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		37C1451A284E06E400D11CC3 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		37C1451C284F9D6500D11CC3 /* NetworkManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManageable.swift; sourceTree = "<group>"; };
+		37C14521284F9EFB00D11CC3 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
+		37C14523284FA17800D11CC3 /* NetworkManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerTests.swift; sourceTree = "<group>"; };
 		37C3F4EC284BF4380006CB02 /* KeychainProvidable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProvidable.swift; sourceTree = "<group>"; };
 		37C3F4EE284BF4450006CB02 /* KeychainProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProvider.swift; sourceTree = "<group>"; };
 		37C3F4F7284C70E40006CB02 /* KeychainQueryRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainQueryRequestable.swift; sourceTree = "<group>"; };
@@ -164,6 +172,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				37654FAE284FBA3600090C3F /* RxTest in Frameworks */,
+				37654FAC284FBA3600090C3F /* RxSwift in Frameworks */,
+				37654FAA284FBA3600090C3F /* RxRelay in Frameworks */,
+				37654FA8284FBA3600090C3F /* RxBlocking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -342,6 +354,7 @@
 				37912C63281445AC0087B95E /* App */,
 				37912C7A281445AD0087B95E /* AppTests */,
 				37912C62281445AC0087B95E /* Products */,
+				37C14525284FB2D000D11CC3 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -481,6 +494,38 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		37C1451E284F9EC500D11CC3 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				37C1451F284F9ECB00D11CC3 /* TestDouble */,
+				37C14520284F9ED100D11CC3 /* Tests */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		37C1451F284F9ECB00D11CC3 /* TestDouble */ = {
+			isa = PBXGroup;
+			children = (
+				37C14521284F9EFB00D11CC3 /* MockURLProtocol.swift */,
+			);
+			path = TestDouble;
+			sourceTree = "<group>";
+		};
+		37C14520284F9ED100D11CC3 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				37C14523284FA17800D11CC3 /* NetworkManagerTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		37C14525284FB2D000D11CC3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		37C3F4EB284BF4020006CB02 /* Keychain */ = {
 			isa = PBXGroup;
 			children = (
@@ -520,6 +565,7 @@
 		37C3F627284D19050006CB02 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				37C1451E284F9EC500D11CC3 /* Network */,
 				37C3F628284D19130006CB02 /* Keychain */,
 			);
 			path = Service;
@@ -591,6 +637,12 @@
 				37912C79281445AD0087B95E /* PBXTargetDependency */,
 			);
 			name = AppTests;
+			packageProductDependencies = (
+				37654FA7284FBA3600090C3F /* RxBlocking */,
+				37654FA9284FBA3600090C3F /* RxRelay */,
+				37654FAB284FBA3600090C3F /* RxSwift */,
+				37654FAD284FBA3600090C3F /* RxTest */,
+			);
 			productName = AppTests;
 			productReference = 37912C77281445AD0087B95E /* AppTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -724,6 +776,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				37C14524284FA17800D11CC3 /* NetworkManagerTests.swift in Sources */,
+				37C14522284F9EFB00D11CC3 /* MockURLProtocol.swift in Sources */,
 				37C3F62C284D194C0006CB02 /* StubKeychainQueryRequester.swift in Sources */,
 				37912C7C281445AD0087B95E /* KeychainProviderTests.swift in Sources */,
 			);
@@ -1042,6 +1096,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 37605E0F283C56B900394929 /* XCRemoteSwiftPackageReference "RxGesture" */;
 			productName = RxGesture;
+		};
+		37654FA7284FBA3600090C3F /* RxBlocking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3770FFEC283112E8001960A0 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxBlocking;
+		};
+		37654FA9284FBA3600090C3F /* RxRelay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3770FFEC283112E8001960A0 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxRelay;
+		};
+		37654FAB284FBA3600090C3F /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3770FFEC283112E8001960A0 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		37654FAD284FBA3600090C3F /* RxTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3770FFEC283112E8001960A0 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxTest;
 		};
 		3770FFED283112E8001960A0 /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/App/App/Sources/Common/Service/Network/HTTPMethod/HTTPMethod.swift
+++ b/App/App/Sources/Common/Service/Network/HTTPMethod/HTTPMethod.swift
@@ -1,0 +1,15 @@
+//
+//  HTTPMethod.swift
+//  App
+//
+//  Created by Hani on 2022/06/06.
+//
+
+import Foundation
+
+enum HTTPMethod {
+    internal static let get = "GET"
+    internal static let post = "POST"
+    internal static let put = "PUT"
+    internal static let delete = "DELETE"
+}

--- a/App/App/Sources/Common/Service/Network/Network/NetworkManageable.swift
+++ b/App/App/Sources/Common/Service/Network/Network/NetworkManageable.swift
@@ -1,0 +1,14 @@
+//
+//  NetworkManageable.swift
+//  App
+//
+//  Created by Hani on 2022/06/07.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol NetworkManageable {
+    func requestDataTask(with request: URLRequest) -> Single<Data>
+}

--- a/App/App/Sources/Common/Service/Network/Network/NetworkManager.swift
+++ b/App/App/Sources/Common/Service/Network/Network/NetworkManager.swift
@@ -19,25 +19,25 @@ final class NetworkManager: NetworkManageable {
     }
     
     internal func requestDataTask(with request: URLRequest) -> Single<Data> {
-        return Single.create { [weak self] single in
+        return Single.create { [weak self] observer -> Disposable in
             self?.session.dataTask(with: request) { data, response, error in
                 if let error = error {
-                    single(.failure(NetworkError.transportError(error)))
+                    observer(.failure(NetworkError.transportError(error)))
                     return
                 }
                
                 if let response = response as? HTTPURLResponse,
                     !(200...299).contains(response.statusCode) {
-                    single(.failure(NetworkError.serverError(statusCode: response.statusCode)))
+                    observer(.failure(NetworkError.serverError(statusCode: response.statusCode)))
                     return
                 }
-               
+                
                 guard let data = data else {
-                    single(.failure(NetworkError.noDataError))
+                    observer(.failure(NetworkError.noDataError))
                     return
                 }
                
-                single(.success(data))
+                observer(.success(data))
  
             }.resume()
             

--- a/App/App/Sources/Common/Service/Network/Network/NetworkManager.swift
+++ b/App/App/Sources/Common/Service/Network/Network/NetworkManager.swift
@@ -1,0 +1,47 @@
+//
+//  NetworkManager.swift
+//  App
+//
+//  Created by Hani on 2022/06/06.
+//
+
+import Foundation
+
+import RxSwift
+
+final class NetworkManager: NetworkManageable {
+    internal static let shared = NetworkManager()
+    
+    private let session: URLSession
+    
+    init(session: URLSession = URLSession(configuration: .default)) {
+        self.session = session
+    }
+    
+    internal func requestDataTask(with request: URLRequest) -> Single<Data> {
+        return Single.create { [weak self] single in
+            self?.session.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    single(.failure(NetworkError.transportError(error)))
+                    return
+                }
+               
+                if let response = response as? HTTPURLResponse,
+                    !(200...299).contains(response.statusCode) {
+                    single(.failure(NetworkError.serverError(statusCode: response.statusCode)))
+                    return
+                }
+               
+                guard let data = data else {
+                    single(.failure(NetworkError.noDataError))
+                    return
+                }
+               
+                single(.success(data))
+ 
+            }.resume()
+            
+            return Disposables.create()
+        }
+    }
+}

--- a/App/App/Sources/Common/Service/Network/NetworkError/NetworkError.swift
+++ b/App/App/Sources/Common/Service/Network/NetworkError/NetworkError.swift
@@ -1,0 +1,14 @@
+//
+//  NetworkError.swift
+//  App
+//
+//  Created by Hani on 2022/06/06.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case transportError(Error)
+    case serverError(statusCode: Int)
+    case noDataError
+}

--- a/App/AppTests/Service/Network/TestDouble/MockURLProtocol.swift
+++ b/App/AppTests/Service/Network/TestDouble/MockURLProtocol.swift
@@ -1,0 +1,46 @@
+//
+//  MockURLProtocol.swift
+//  AppTests
+//
+//  Created by Hani on 2022/06/07.
+//
+
+import Foundation
+import XCTest
+
+import RxSwift
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    override func stopLoading() { }
+    
+    override func startLoading() {
+        guard let requestHandler = MockURLProtocol.requestHandler else {
+            XCTFail("MockURLProtocol`s requestHandler was not initialized")
+            return
+        }
+        
+        do {
+            let (response, data) = try requestHandler(request)
+            
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+}

--- a/App/AppTests/Service/Network/Tests/NetworkManagerTests.swift
+++ b/App/AppTests/Service/Network/Tests/NetworkManagerTests.swift
@@ -1,0 +1,102 @@
+//
+//  NetworkManagerTests.swift
+//  AppTests
+//
+//  Created by Hani on 2022/06/08.
+//
+
+import XCTest
+
+import RxBlocking
+import RxTest
+
+@testable import App
+
+final class NetworkManagerTests: XCTestCase {
+    private var sut: NetworkManager!
+    private var urlSession: URLSession!
+    
+    override func setUpWithError() throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        urlSession = URLSession(configuration: configuration)
+        
+        sut = NetworkManager(session: urlSession)
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        MockURLProtocol.requestHandler = nil
+        urlSession = nil
+    }
+
+    func test_DataTask요청했으나_Transport에러때문에_실패() throws {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            throw NetworkError.transportError(DummyError())
+        }
+        
+        // When
+        XCTAssertThrowsError(try sut.requestDataTask(with: Dummy.urlRequest).toBlocking(timeout: 0.5).single()) { error in
+            
+            // Then
+            XCTAssertEqual(error as? NetworkError, NetworkError.transportError(DummyError()))
+        }
+    }
+    
+    func test_DataTask요청했으나_Server에러때문에_실패() throws {
+        // Given
+        let ServerErrorStatusCode = 400
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: Dummy.url, statusCode: ServerErrorStatusCode, httpVersion: Dummy.httpVersion, headerFields: Dummy.headerFields)!
+            return (response, nil)
+        }
+        
+        // When
+        XCTAssertThrowsError(try sut.requestDataTask(with: Dummy.urlRequest).toBlocking(timeout: 0.5).single()) { error in
+            
+            // Then
+            XCTAssertEqual(error as? NetworkError, NetworkError.serverError(statusCode: ServerErrorStatusCode))
+        }
+    }
+    
+    func test_DataTask요청_성공() throws {
+        // Given
+        let expected = Data()
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: Dummy.url, statusCode: 200, httpVersion: Dummy.httpVersion, headerFields: Dummy.headerFields)!
+            return (response, expected)
+        }
+        
+        // When
+        let result = try sut.requestDataTask(with: Dummy.urlRequest).toBlocking(timeout: 0.5).single()
+        
+        // Then
+        XCTAssertEqual(result, expected)
+    }
+}
+
+private enum Dummy {
+    static let url = URL(string: "https://www.yapp.co.kr/")!
+    static let urlRequest = URLRequest(url: url)
+    static let statusCode = 200
+    static let httpVersion = "2.0"
+    static let headerFields: [String: String]? = nil
+}
+
+private struct DummyError: Error { }
+
+extension NetworkError: Equatable {
+    public static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+        switch (lhs, rhs) {
+        case (.noDataError, .noDataError):
+            return true
+        case (.serverError(let lhsCode), .serverError(let rhsCode)):
+            return lhsCode == rhsCode
+        case (.transportError(_), .transportError(_)):
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용 💾
- [x] 실제 네트워킹을 하지 않는 테스트 코드 작성
- [x] 비동기 처리를 RxSwift를 이용
- [x] 생성된 모듈에 관한 추상화
- [x] 네트워킹을 위한 Encode/Decode를 해당 모듈에서 지원하지 않기
- [ ] 서버에 요청하기 위한 APIKey 은닉화

## 관련 이슈 🔗
https://github.com/YAPP-Github/20th-iOS-Team-1-FE/issues/9


## 코드 커버리지 📸
NetworkManager 97%
<img width="1386" alt="Screen Shot 2022-06-08 at 3 58 50 AM" src="https://user-images.githubusercontent.com/53580563/172461141-8bfc08dd-5847-40d1-aa18-dd3869d52b59.png">


## 리뷰어분들께 💚
APIKey 은닉화 다른 PR에서 진행
noDataError에 대한 테스트 추후 진행
AppTests 타겟에 RxBlocking, RxTest 추가