### PR TITLE
[feat] 텍스트필드 키보드 반응 추가

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		37348B0A2866BA1F00C38F70 /* SignUpInfomationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37348B092866BA1F00C38F70 /* SignUpInfomationCoordinator.swift */; };
 		37348B0C2866CA5E00C38F70 /* BorderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37348B0B2866CA5E00C38F70 /* BorderButton.swift */; };
 		29AE22522869E47100EDF34B /* MapViewAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AE22512869E47100EDF34B /* MapViewAnnotation.swift */; };
+		3734CEAA2869E70C00EEF38D /* SignUpRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3734CEA92869E70C00EEF38D /* SignUpRepositoryInterface.swift */; };
+		3734CEAC2869E72100EEF38D /* SignUpRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3734CEAB2869E72100EEF38D /* SignUpRepository.swift */; };
+		3734CEAE2869E7E700EEF38D /* SignUpAccountDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3734CEAD2869E7E700EEF38D /* SignUpAccountDTO.swift */; };
+		3734CEB12869F6DD00EEF38D /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = 3734CEB02869F6DD00EEF38D /* RxKeyboard */; };
 		37438095284FD9BA00CB02A5 /* ExceptionDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37438094284FD9BA00CB02A5 /* ExceptionDetailResponseDTO.swift */; };
 		37438097284FD9F800CB02A5 /* ExceptionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37438096284FD9F800CB02A5 /* ExceptionResponseDTO.swift */; };
 		3743809D284FDB5300CB02A5 /* ExceptionResponseInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3743809C284FDB5300CB02A5 /* ExceptionResponseInfoDTO.swift */; };
@@ -80,7 +84,7 @@
 		377370842841BE1000D5CCB6 /* UIButton+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377370832841BE1000D5CCB6 /* UIButton+Rx.swift */; };
 		377370882841DE3500D5CCB6 /* SignUpProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377370862841DE3500D5CCB6 /* SignUpProfileViewController.swift */; };
 		377370892841DE3500D5CCB6 /* SignUpProfileReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377370872841DE3500D5CCB6 /* SignUpProfileReactor.swift */; };
-		3773708C2841DE6D00D5CCB6 /* UserAuthentification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3773708B2841DE6D00D5CCB6 /* UserAuthentification.swift */; };
+		3773708C2841DE6D00D5CCB6 /* UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3773708B2841DE6D00D5CCB6 /* UserAccount.swift */; };
 		378F347A281DBDF10063CE4F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378F3478281DBDF10063CE4F /* LoginViewController.swift */; };
 		378F347B281DBDF10063CE4F /* LoginReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378F3479281DBDF10063CE4F /* LoginReactor.swift */; };
 		378F347E281DBE070063CE4F /* GatherListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378F347C281DBE070063CE4F /* GatherListViewController.swift */; };
@@ -177,6 +181,9 @@
 		37348B092866BA1F00C38F70 /* SignUpInfomationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInfomationCoordinator.swift; sourceTree = "<group>"; };
 		37348B0B2866CA5E00C38F70 /* BorderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderButton.swift; sourceTree = "<group>"; };
 		29AE22512869E47100EDF34B /* MapViewAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewAnnotation.swift; sourceTree = "<group>"; };
+		3734CEA92869E70C00EEF38D /* SignUpRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRepositoryInterface.swift; sourceTree = "<group>"; };
+		3734CEAB2869E72100EEF38D /* SignUpRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRepository.swift; sourceTree = "<group>"; };
+		3734CEAD2869E7E700EEF38D /* SignUpAccountDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpAccountDTO.swift; sourceTree = "<group>"; };
 		37438094284FD9BA00CB02A5 /* ExceptionDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExceptionDetailResponseDTO.swift; sourceTree = "<group>"; };
 		37438096284FD9F800CB02A5 /* ExceptionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExceptionResponseDTO.swift; sourceTree = "<group>"; };
 		3743809C284FDB5300CB02A5 /* ExceptionResponseInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExceptionResponseInfoDTO.swift; sourceTree = "<group>"; };
@@ -224,7 +231,7 @@
 		377370832841BE1000D5CCB6 /* UIButton+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Rx.swift"; sourceTree = "<group>"; };
 		377370862841DE3500D5CCB6 /* SignUpProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpProfileViewController.swift; sourceTree = "<group>"; };
 		377370872841DE3500D5CCB6 /* SignUpProfileReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpProfileReactor.swift; sourceTree = "<group>"; };
-		3773708B2841DE6D00D5CCB6 /* UserAuthentification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuthentification.swift; sourceTree = "<group>"; };
+		3773708B2841DE6D00D5CCB6 /* UserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAccount.swift; sourceTree = "<group>"; };
 		378F3478281DBDF10063CE4F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		378F3479281DBDF10063CE4F /* LoginReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginReactor.swift; sourceTree = "<group>"; };
 		378F347C281DBE070063CE4F /* GatherListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatherListViewController.swift; sourceTree = "<group>"; };
@@ -301,6 +308,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3770FFF0283112E8001960A0 /* RxSwift in Frameworks */,
+				3734CEB12869F6DD00EEF38D /* RxKeyboard in Frameworks */,
 				3770FFF3283112F4001960A0 /* ReactorKit in Frameworks */,
 				37605E11283C56B900394929 /* RxGesture in Frameworks */,
 				37451F252834245100696B21 /* WeakMapTable in Frameworks */,
@@ -359,6 +367,7 @@
 			children = (
 				379B1A78285A52DA00E58A34 /* AppleLoginRepository.swift */,
 				374F41CC2864E5250074F04B /* AccountValidationRepository.swift */,
+				3734CEAB2869E72100EEF38D /* SignUpRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -383,6 +392,7 @@
 				37AA7E1B2850B1C400B4B5C2 /* StatusDTO.swift */,
 				379B1A76285A4F7700E58A34 /* AppleCredentialRequestDTO.swift */,
 				374F41CE2864E6C60074F04B /* AccountValidationResponseDTO.swift */,
+				3734CEAD2869E7E700EEF38D /* SignUpAccountDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -412,6 +422,7 @@
 				375558BC2866E0AC00D13208 /* SignUpAreaViewController.swift */,
 				375558BD2866E0AC00D13208 /* SignUpAreaReactor.swift */,
 				375558C02867905800D13208 /* SignUpAreaCoordinator.swift */,
+				3734CEA92869E70C00EEF38D /* SignUpRepositoryInterface.swift */,
 			);
 			path = SignUpAreaScene;
 			sourceTree = "<group>";
@@ -525,7 +536,7 @@
 		3773708A2841DE4800D5CCB6 /* Entity */ = {
 			isa = PBXGroup;
 			children = (
-				3773708B2841DE6D00D5CCB6 /* UserAuthentification.swift */,
+				3773708B2841DE6D00D5CCB6 /* UserAccount.swift */,
 				37AA7E1D2850B37B00B4B5C2 /* Sex.swift */,
 				37AA7E202851FCA200B4B5C2 /* Authentification.swift */,
 			);
@@ -908,6 +919,7 @@
 				3770FFF2283112F4001960A0 /* ReactorKit */,
 				37451F242834245100696B21 /* WeakMapTable */,
 				37605E10283C56B900394929 /* RxGesture */,
+				3734CEB02869F6DD00EEF38D /* RxKeyboard */,
 			);
 			productName = App;
 			productReference = 37912C61281445AC0087B95E /* App.app */;
@@ -970,6 +982,7 @@
 				3770FFF1283112F4001960A0 /* XCRemoteSwiftPackageReference "ReactorKit" */,
 				37451F232834245100696B21 /* XCRemoteSwiftPackageReference "WeakMapTable" */,
 				37605E0F283C56B900394929 /* XCRemoteSwiftPackageReference "RxGesture" */,
+				3734CEAF2869F6DD00EEF38D /* XCRemoteSwiftPackageReference "RxKeyboard" */,
 			);
 			productRefGroup = 37912C62281445AC0087B95E /* Products */;
 			projectDirPath = "";
@@ -1013,6 +1026,7 @@
 				29AE2238284B941800EDF34B /* GatherCategory.swift in Sources */,
 				378F3487281DBE210063CE4F /* ProfileReactor.swift in Sources */,
 				37912C9A281447C40087B95E /* Array+Extension.swift in Sources */,
+				3734CEAE2869E7E700EEF38D /* SignUpAccountDTO.swift in Sources */,
 				3743809D284FDB5300CB02A5 /* ExceptionResponseInfoDTO.swift in Sources */,
 				374380A9284FDDC600CB02A5 /* TokenResponseDTO.swift in Sources */,
 				37605E01283A2AE200394929 /* RxASAuthorizationControllerPresentationContextProvidingProxy.swift in Sources */,
@@ -1075,13 +1089,14 @@
 				FDBC12102868CD4C00FCADF4 /* DogTableViewCell.swift in Sources */,
 				37AA7E212851FCA200B4B5C2 /* Authentification.swift in Sources */,
 				37AA7E162850B17600B4B5C2 /* EligibleBreedDTO.swift in Sources */,
+				3734CEAA2869E70C00EEF38D /* SignUpRepositoryInterface.swift in Sources */,
 				37C3F4FC284C7D8B0006CB02 /* KeychainError.swift in Sources */,
 				37AA7E142850B15800B4B5C2 /* CategoryDTO.swift in Sources */,
 				378F3483281DBE140063CE4F /* ChattingReactor.swift in Sources */,
 				376006C528489A2B00B27015 /* RegularExpressionValidator.swift in Sources */,
 				29AE224C2853711F00EDF34B /* RxMKMapViewDelegateProxy.swift in Sources */,
 				374F41CD2864E5250074F04B /* AccountValidationRepository.swift in Sources */,
-				3773708C2841DE6D00D5CCB6 /* UserAuthentification.swift in Sources */,
+				3773708C2841DE6D00D5CCB6 /* UserAccount.swift in Sources */,
 				FDE6F14C285234A3005E4783 /* NSObject+Extension.swift in Sources */,
 				374F41D52864E9490074F04B /* KeychainService.swift in Sources */,
 				37605DF92839FDB300394929 /* ASAuthorizationController+Rx.swift in Sources */,
@@ -1100,6 +1115,7 @@
 				379B1A7D285A580D00E58A34 /* SignInResult.swift in Sources */,
 				378F347B281DBDF10063CE4F /* LoginReactor.swift in Sources */,
 				37912C65281445AC0087B95E /* AppDelegate.swift in Sources */,
+				3734CEAC2869E72100EEF38D /* SignUpRepository.swift in Sources */,
 				374380AF284FE13300CB02A5 /* SearchingResponseDTO.swift in Sources */,
 				374F41D72864E97A0074F04B /* KeychainAccount.swift in Sources */,
 				29AE222D284B7DAA00EDF34B /* SearchViewController.swift in Sources */,
@@ -1415,6 +1431,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		3734CEAF2869F6DD00EEF38D /* XCRemoteSwiftPackageReference "RxKeyboard" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RxSwiftCommunity/RxKeyboard";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		37451F232834245100696B21 /* XCRemoteSwiftPackageReference "WeakMapTable" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactorKit/WeakMapTable";
@@ -1450,6 +1474,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3734CEB02869F6DD00EEF38D /* RxKeyboard */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3734CEAF2869F6DD00EEF38D /* XCRemoteSwiftPackageReference "RxKeyboard" */;
+			productName = RxKeyboard;
+		};
 		37451F242834245100696B21 /* WeakMapTable */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 37451F232834245100696B21 /* XCRemoteSwiftPackageReference "WeakMapTable" */;

--- a/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "reactorkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactorKit/ReactorKit",
+      "state" : {
+        "revision" : "8fa33f09c6f6621a2aa536d739956d53b84dd139",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "rxgesture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxGesture",
+      "state" : {
+        "revision" : "1b137c576b4aaaab949235752278956697c9e4a0",
+        "version" : "4.0.4"
+      }
+    },
+    {
+      "identity" : "rxkeyboard",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxKeyboard",
+      "state" : {
+        "revision" : "085fd99d7bb4f98e671904fcfe7ff561e66574ad",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift",
+      "state" : {
+        "revision" : "b4307ba0b6425c0ba4178e138799946c3da594f8",
+        "version" : "6.5.0"
+      }
+    },
+    {
+      "identity" : "weakmaptable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactorKit/WeakMapTable.git",
+      "state" : {
+        "revision" : "cb05d64cef2bbf51e85c53adee937df46540a74e",
+        "version" : "1.2.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/App/App/Sources/Common/Service/Network/DTO/SignUpAccountDTO.swift
+++ b/App/App/Sources/Common/Service/Network/DTO/SignUpAccountDTO.swift
@@ -1,0 +1,43 @@
+//
+//  SignUpAccountDTO.swift
+//  App
+//
+//  Created by Hani on 2022/06/27.
+//
+
+import Foundation
+
+struct SignUpAccountDTO: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case nickname
+        case imageFile
+        case age
+        case sex
+        case city
+        case detail
+    }
+    
+    internal let nickname: String
+    internal let imageFile: Data?
+    internal let age: Int
+    internal let sex: String
+    internal let city: String
+    internal let detail: String
+    
+    init?(user: UserAccount) {
+        guard let nickname = user.nickName,
+              let age = user.age,
+              let sex = user.sex,
+              let city = user.bigCity,
+              let detail = user.smallCity else {
+            return nil
+        }
+
+        self.nickname = nickname
+        self.imageFile = user.profileImageData
+        self.age = age
+        self.sex = sex
+        self.city = city
+        self.detail = detail
+    }
+}

--- a/App/App/Sources/Common/Service/Network/Network/NetworkManager.swift
+++ b/App/App/Sources/Common/Service/Network/Network/NetworkManager.swift
@@ -29,31 +29,23 @@ final class NetworkManager: NetworkManageable {
                     observer(.failure(NetworkError.transportError(error)))
                     return
                 }
-                guard let data = data else {
-                    observer(.failure(NetworkError.noDataError))
-                    return
-                }
-                
                 if let response = response as? HTTPURLResponse,
                     !(200...299).contains(response.statusCode) {
                     observer(.failure(NetworkError.serverError(statusCode: response.statusCode)))
                     return
                 }
                 
+                guard let data = data else {
+                    observer(.failure(NetworkError.noDataError))
+                    return
+                }
+                
+            
                 guard let decodedData = try? JSONDecoder().decode(T.self, from: data) else {
                     observer(.failure(NetworkError.decodeError))
                     return
                 }
-//                guard let data = data else {
-//                    observer(.failure(NetworkError.noDataError))
-//                    return
-//                }
-//                
-//                guard let decodedData = try? JSONDecoder().decode(T.self, from: data) else {
-//                    observer(.failure(NetworkError.decodeError))
-//                    return
-//                }
-//               
+                
                 observer(.success(decodedData))
  
             }

--- a/App/App/Sources/Scenes/AuthScene/Entity/UserAccount.swift
+++ b/App/App/Sources/Scenes/AuthScene/Entity/UserAccount.swift
@@ -7,10 +7,12 @@
 
 import Foundation
 
-struct UserAuthentification: Equatable {
+struct UserAccount: Equatable {
     var email: String? = nil
     var profileImageData: Data? = nil
     var nickName: String? = nil
     var age: Int? = nil
-    var sex: Sex?
+    var sex: String?
+    var bigCity: String?
+    var smallCity: String?
 }

--- a/App/App/Sources/Scenes/AuthScene/SignUpAgreementScene/SignUpAgreementCoordinator.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpAgreementScene/SignUpAgreementCoordinator.swift
@@ -35,7 +35,7 @@ final class SignUpAgreementCoordinator: SceneCoordinator {
         navigationController.pushViewController(signUpAgreementViewController, animated: true)
     }
     
-    private func pushSignUpProfileViewController(with user: UserAuthentification) {
+    private func pushSignUpProfileViewController(with user: UserAccount) {
         let signUpProfileCoordinator = SignUpProfileCoordinator(navigationController: navigationController, user: user)
         signUpProfileCoordinator.parentCoordinator = self
         childCoordinators.append(signUpProfileCoordinator)

--- a/App/App/Sources/Scenes/AuthScene/SignUpAgreementScene/SignUpAgreementReactor.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpAgreementScene/SignUpAgreementReactor.swift
@@ -28,7 +28,7 @@ final class SignUpAgreementReactor: Reactor {
     }
     
     struct State {
-        let user = UserAuthentification()
+        let user = UserAccount()
         var isAgreementChecked = false
         var isTermsOfServiceChecked = false
         var isPrivacyPolicyChecked = false

--- a/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpAreaCoordinator.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpAreaCoordinator.swift
@@ -9,23 +9,39 @@ import UIKit
 import RxSwift
 
 final class SignUpAreaCoordinator: SceneCoordinator {
-    private var user: UserAuthentification
+    private var user: UserAccount
     
     var parentCoordinator: SceneCoordinator?
     var navigationController: UINavigationController
     var childCoordinators = [Coordinator]()
     var disposeBag = DisposeBag()
     
-    init(navigationController: UINavigationController, user: UserAuthentification) {
+    init(navigationController: UINavigationController, user: UserAccount) {
         self.navigationController = navigationController
         self.user = user
     }
     
     func start() {
-        let signUpAreaReactor = SignUpAreaReactor(user: user)
+        let networkManager = NetworkManager.shared
+        let signUpRepository = SignUpRepository(networkManager: networkManager)
+        let keychain = KeychainQueryRequester()
+        let keychainProvider = KeychainProvider(keyChain: keychain)
+        let keychainUseCase = KeychainUsecase(keychainProvider: keychainProvider, networkManager: networkManager)
+        let signUpAreaReactor = SignUpAreaReactor(user: user, keychainUseCase: keychainUseCase, signUpRepository: signUpRepository)
         let signUpAreaViewController = SignUpAreaViewController(reactor: signUpAreaReactor)
-
+        
+        signUpAreaReactor.state
+            .distinctUntilChanged(\.isReadyToStartTogaether)
+            .withUnretained(self)
+            .subscribe(onNext: { (this, user) in
+                
+            })
+            .disposed(by: disposeBag)
+        
         navigationController.pushViewController(signUpAreaViewController, animated: true)
     }
     
+    private func startTogaether() {
+        
+    }
 }

--- a/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpAreaViewController.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpAreaViewController.swift
@@ -163,7 +163,12 @@ final class SignUpAreaViewController: BaseViewController {
         configureLayout()
         configureUI()
     }
-
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        view.endEditing(true)
+    }
+    
     private func addSubviews() {
         view.addSubview(guidanceLabel)
         
@@ -180,6 +185,7 @@ final class SignUpAreaViewController: BaseViewController {
     }
     
     private func configureLayout() {
+        guidanceLabel.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         NSLayoutConstraint.useAndActivateConstraints([
             guidanceLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 96),
             guidanceLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
@@ -281,7 +287,13 @@ final class SignUpAreaViewController: BaseViewController {
                 .map { $0.isNextButtonEnabled }
                 .distinctUntilChanged()
                 .asDriver(onErrorJustReturn: false)
-                .drive(nextButton.rx.isEnabled)
+                .drive(with: self,
+                   onNext: { this, isEnabled in
+                    this.nextButton.isEnabled = isEnabled
+                    if isEnabled {
+                        this.nextButton.becomeFirstResponder()
+                    }
+                })
         }
     }
     

--- a/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpRepositoryInterface.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpRepositoryInterface.swift
@@ -1,0 +1,14 @@
+//
+//  SignUpRepositoryInterface.swift
+//  App
+//
+//  Created by Hani on 2022/06/27.
+//
+
+import Foundation
+
+import RxSwift 
+
+protocol SignUpRepositoryInterface {
+    func signUp(user: UserAccount, accessToken: Data) -> Single<Void>
+}

--- a/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationCoordinator.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationCoordinator.swift
@@ -10,14 +10,14 @@ import UIKit
 import RxSwift
 
 final class SignUpInfomationCoordinator: SceneCoordinator {
-    private var user: UserAuthentification
+    private var user: UserAccount
     
     var parentCoordinator: SceneCoordinator?
     var navigationController: UINavigationController
     var childCoordinators = [Coordinator]()
     var disposeBag = DisposeBag()
     
-    init(navigationController: UINavigationController, user: UserAuthentification) {
+    init(navigationController: UINavigationController, user: UserAccount) {
         self.navigationController = navigationController
         self.user = user
     }
@@ -38,7 +38,7 @@ final class SignUpInfomationCoordinator: SceneCoordinator {
         navigationController.pushViewController(signUpInfomationViewController, animated: true)
     }
     
-    private func pushSignUpAreaViewController(with user: UserAuthentification) {
+    private func pushSignUpAreaViewController(with user: UserAccount) {
         let signUpAreaCoordinator = SignUpAreaCoordinator(navigationController: navigationController, user: user)
         signUpAreaCoordinator.parentCoordinator = self
         childCoordinators.append(signUpAreaCoordinator)

--- a/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationReactor.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationReactor.swift
@@ -28,7 +28,7 @@ final class SignUpInfomationReactor: Reactor {
     }
     
     struct State {
-        var user: UserAuthentification
+        var user: UserAccount
         var isManSelected = false
         var isWomanSelected = false
         var isPrivateSexSelected = false
@@ -38,7 +38,7 @@ final class SignUpInfomationReactor: Reactor {
     
     let initialState: State
     
-    init(user: UserAuthentification) {
+    init(user: UserAccount) {
         initialState = State(user: user)
     }
     
@@ -65,16 +65,19 @@ final class SignUpInfomationReactor: Reactor {
             newState.user.age = age
             newState.isNextButtonEnabled = newState.user.age != nil && (newState.isManSelected || newState.isWomanSelected || newState.isPrivateSexSelected)
         case .selectMan:
+            newState.user.sex = Sex.man
             newState.isManSelected = true
             newState.isWomanSelected = false
             newState.isPrivateSexSelected = false
             newState.isNextButtonEnabled = newState.user.age != nil && (newState.isManSelected || newState.isWomanSelected || newState.isPrivateSexSelected)
         case .selectWoman:
+            newState.user.sex = Sex.woman
             newState.isManSelected = false
             newState.isWomanSelected = true
             newState.isPrivateSexSelected = false
             newState.isNextButtonEnabled = newState.user.age != nil && (newState.isManSelected || newState.isWomanSelected || newState.isPrivateSexSelected)
         case .selectPrivateSex:
+            newState.user.sex = Sex.private
             newState.isManSelected = false
             newState.isWomanSelected = false
             newState.isPrivateSexSelected = true

--- a/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileCoordinator.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileCoordinator.swift
@@ -10,14 +10,14 @@ import UIKit
 import RxSwift
 
 final class SignUpProfileCoordinator: SceneCoordinator {
-    private var user: UserAuthentification
+    private var user: UserAccount
     
     var parentCoordinator: SceneCoordinator?
     var navigationController: UINavigationController
     var childCoordinators = [Coordinator]()
     var disposeBag = DisposeBag()
     
-    init(navigationController: UINavigationController, user: UserAuthentification) {
+    init(navigationController: UINavigationController, user: UserAccount) {
         self.navigationController = navigationController
         self.user = user
     }
@@ -44,7 +44,7 @@ final class SignUpProfileCoordinator: SceneCoordinator {
         navigationController.pushViewController(signUpProfileViewController, animated: true)
     }
     
-    private func pushSignUpInfomationViewController(with user: UserAuthentification) {
+    private func pushSignUpInfomationViewController(with user: UserAccount) {
         let signUpInfomationCoordinator = SignUpInfomationCoordinator(navigationController: navigationController, user: user)
         signUpInfomationCoordinator.parentCoordinator = self
         childCoordinators.append(signUpInfomationCoordinator)

--- a/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileReactor.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileReactor.swift
@@ -28,7 +28,7 @@ final class SignUpProfileReactor: Reactor {
     
     struct State {
         var nickname = ""
-        var user: UserAuthentification
+        var user: UserAccount
         var isNicknameValidationCheckDone = false
         var isNicknameDuplicateCheckDone = false
         var isReadyToProceedWithSignUp = false
@@ -41,7 +41,7 @@ final class SignUpProfileReactor: Reactor {
     private let keychainUseCase: KeychainUseCaseInterface
     private let disposeBag = DisposeBag()
     
-    init(user: UserAuthentification, regularExpressionValidator: RegularExpressionValidatable, accountValidationRepository: AccountValidationRepositoryInterface, keychainUseCase: KeychainUseCaseInterface) {
+    init(user: UserAccount, regularExpressionValidator: RegularExpressionValidatable, accountValidationRepository: AccountValidationRepositoryInterface, keychainUseCase: KeychainUseCaseInterface) {
         self.initialState = State(user: user)
         self.regularExpressionValidator = regularExpressionValidator
         self.accountValidationRepository = accountValidationRepository

--- a/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileViewController.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileViewController.swift
@@ -10,9 +10,14 @@ import UIKit
 
 import ReactorKit
 import RxCocoa
+import RxKeyboard
 
 final class SignUpProfileViewController: BaseViewController {
-    private var guidanceLabel: UILabel = {
+    private let scrollView = UIScrollView()
+    
+    private let contentView = UIView()
+    
+    private let guidanceLabel: UILabel = {
         let text = "견주님의 프로필과\n닉네임을 등록해주세요."
         let boldFont = UIFont.boldSystemFont(ofSize: 32)
         let attributedText = NSMutableAttributedString(string: text)
@@ -105,6 +110,8 @@ final class SignUpProfileViewController: BaseViewController {
         return picker
     }()
     
+    private var nicknameTextFieldConstraint: NSLayoutConstraint?
+    
     var disposeBag = DisposeBag()
     
     init(reactor: SignUpProfileReactor) {
@@ -124,65 +131,91 @@ final class SignUpProfileViewController: BaseViewController {
         configureUI()
         imagePicker.delegate = self
     }
-
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        nicknameTextField.becomeFirstResponder()
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        view.endEditing(true)
+    }
+    
     private func addSubviews() {
-        view.addSubview(guidanceLabel)
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
         
-        view.addSubview(profileImageView)
-        view.addSubview(profileRegisterButton)
+        contentView.addSubview(guidanceLabel)
         
-        view.addSubview(nickNameLabel)
+        contentView.addSubview(profileImageView)
+        contentView.addSubview(profileRegisterButton)
         
-        view.addSubview(nicknameTextField)
-        view.addSubview(duplicateCheckButton)
-        view.addSubview(deleteButton)
+        contentView.addSubview(nickNameLabel)
         
-        view.addSubview(nicknameContourView)
+        contentView.addSubview(nicknameTextField)
+        contentView.addSubview(duplicateCheckButton)
+        contentView.addSubview(deleteButton)
         
-        view.addSubview(nextButtonContourView)
-        view.addSubview(nextButton)
+        contentView.addSubview(nicknameContourView)
+        
+        contentView.addSubview(nextButtonContourView)
+        contentView.addSubview(nextButton)
     }
     
     private func configureLayout() {
         NSLayoutConstraint.useAndActivateConstraints([
-            guidanceLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 96),
-            guidanceLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            guidanceLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            contentView.heightAnchor.constraint(greaterThanOrEqualTo: view.heightAnchor),
+            
+            guidanceLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 96),
+            guidanceLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            guidanceLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             
             profileImageView.topAnchor.constraint(equalTo: guidanceLabel.bottomAnchor, constant: 72),
-            profileImageView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.5),
+            profileImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.5),
             profileImageView.heightAnchor.constraint(equalTo: profileImageView.widthAnchor),
-            profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            profileImageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             
             profileRegisterButton.centerXAnchor.constraint(equalTo: profileImageView.centerXAnchor),
             profileRegisterButton.centerYAnchor.constraint(equalTo: profileImageView.centerYAnchor),
             
             nickNameLabel.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 57),
-            nickNameLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            nickNameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             
             nicknameTextField.topAnchor.constraint(equalTo: nickNameLabel.bottomAnchor, constant: 5),
-            nicknameTextField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            nicknameTextField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             
-            duplicateCheckButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            duplicateCheckButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             duplicateCheckButton.centerYAnchor.constraint(equalTo: nicknameTextField.centerYAnchor),
             
             deleteButton.trailingAnchor.constraint(equalTo: duplicateCheckButton.leadingAnchor, constant: -8),
             deleteButton.centerYAnchor.constraint(equalTo: duplicateCheckButton.centerYAnchor),
   
             nicknameContourView.topAnchor.constraint(equalTo: deleteButton.bottomAnchor, constant: 10),
-            nicknameContourView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            nicknameContourView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            nicknameContourView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            nicknameContourView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             nicknameContourView.heightAnchor.constraint(equalToConstant: 1),
-      
-            nextButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            nextButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
-            nextButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -4),
+            
+            nextButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            nextButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            nextButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4),
             nextButton.heightAnchor.constraint(equalToConstant: 50),
             
-            nextButtonContourView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            nextButtonContourView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            nextButtonContourView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            nextButtonContourView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             nextButtonContourView.bottomAnchor.constraint(equalTo: nextButton.topAnchor, constant: -14),
-            nextButtonContourView.heightAnchor.constraint(equalToConstant: 1)
+            nextButtonContourView.heightAnchor.constraint(equalToConstant: 1),
+            nextButtonContourView.topAnchor.constraint(greaterThanOrEqualTo: nicknameContourView.bottomAnchor, constant: 50)
         ])
     }
     
@@ -215,6 +248,13 @@ final class SignUpProfileViewController: BaseViewController {
                     
                     self.present(self.imagePicker, animated: true)
                 })
+            
+            RxKeyboard.instance.visibleHeight
+                .skip(1)
+                .drive(with: self,
+                   onNext: { this, keyboardHeight in
+                    this.scrollView.contentInset.bottom = keyboardHeight
+                })
         }
     }
     
@@ -230,7 +270,14 @@ final class SignUpProfileViewController: BaseViewController {
                 .map { $0.isNicknameDuplicateCheckDone }
                 .distinctUntilChanged()
                 .asDriver(onErrorJustReturn: false)
-                .drive(nextButton.rx.isEnabled)
+                .drive(with: self,
+                   onNext: { this, isEnabled in
+                    this.nextButton.isEnabled = isEnabled
+                    this.nicknameTextField.resignFirstResponder()
+                    if isEnabled {
+                        this.nextButton.becomeFirstResponder()
+                    }
+                })
         }
     }
     


### PR DESCRIPTION
## 작업 내용 💾
- [x] RxKeyboard 추가
- [x] 유저 정보 넘기기위한 DTO 추가
- [x] 투개더 시작하기 버튼 누르면 서버에 유저 정보 넘어가도록 구현
- [x] 유저 사진, 닉네임 화면 키보드 인터렉션 구현
    - 화면 진입할 때 텍스트필드 becomeFirstResponder, 키보드 등장
    - 중복확인 버튼 탭하면 텍스트필드 resignFirstResponder, 키보드 사라짐
    - 중복확인 성공하면 넥스트버튼 becomeFirstResponder

## 관련 이슈 🔗
https://github.com/YAPP-Github/20th-iOS-Team-1-FE/issues/33

## 리뷰어분들께 💚
키보드 구현을 잘 못해서, 노티피케이션 쓰기 어려워서 RxKeyboard 도입
단, 그래도 어려워서 스크롤뷰를 일부 도입.. 예쁘게 구현 아직 안됨