### PR TITLE
[feat] 공통 - 코디네이터 패턴 버리기

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		37C3F4FA284C71030006CB02 /* KeychainQueryRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4F9284C71030006CB02 /* KeychainQueryRequester.swift */; };
 		37C3F4FC284C7D8B0006CB02 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F4FB284C7D8B0006CB02 /* KeychainError.swift */; };
 		37C3F62C284D194C0006CB02 /* StubKeychainQueryRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C3F62B284D194C0006CB02 /* StubKeychainQueryRequester.swift */; };
+		37F67CC5286A1C270073FE8C /* AA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F67CC4286A1C270073FE8C /* AA.swift */; };
 		FD8AD7052851E26200454AC3 /* GatherListTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8AD7042851E26200454AC3 /* GatherListTableView.swift */; };
 		FD8AD7072851E28000454AC3 /* GatherListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8AD7062851E28000454AC3 /* GatherListCell.swift */; };
 		FD8AD7092851E2AA00454AC3 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8AD7082851E2AA00454AC3 /* PaddingLabel.swift */; };
@@ -283,6 +284,7 @@
 		37C3F4F9284C71030006CB02 /* KeychainQueryRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainQueryRequester.swift; sourceTree = "<group>"; };
 		37C3F4FB284C7D8B0006CB02 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
 		37C3F62B284D194C0006CB02 /* StubKeychainQueryRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubKeychainQueryRequester.swift; sourceTree = "<group>"; };
+		37F67CC4286A1C270073FE8C /* AA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AA.swift; sourceTree = "<group>"; };
 		FD8AD7042851E26200454AC3 /* GatherListTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatherListTableView.swift; sourceTree = "<group>"; };
 		FD8AD7062851E28000454AC3 /* GatherListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatherListCell.swift; sourceTree = "<group>"; };
 		FD8AD7082851E2AA00454AC3 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				37605DEE2839547200394929 /* AuthCoordinator.swift */,
 				37912CA528144A530087B95E /* TabCoordinator.swift */,
 				37912CA328144A260087B95E /* Protocol */,
+				37F67CC4286A1C270073FE8C /* AA.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -1128,6 +1131,7 @@
 				376006CA28490EFD00B27015 /* EnableButton.swift in Sources */,
 				37348B0A2866BA1F00C38F70 /* SignUpInfomationCoordinator.swift in Sources */,
 				379B1A79285A52DA00E58A34 /* AppleLoginRepository.swift in Sources */,
+				37F67CC5286A1C270073FE8C /* AA.swift in Sources */,
 				378F3486281DBE210063CE4F /* ProfileViewController.swift in Sources */,
 				FDBC12042866858900FCADF4 /* ProfileContentView.swift in Sources */,
 				378F348B281DC0560063CE4F /* GatherListCoordinator.swift in Sources */,

--- a/App/App/Sources/Common/Coordinator/AA.swift
+++ b/App/App/Sources/Common/Coordinator/AA.swift
@@ -1,0 +1,115 @@
+//
+//  AA.swift
+//  App
+//
+//  Created by Hani on 2022/06/28.
+//
+
+import UIKit
+
+import RxSwift
+
+final class AA: Coordinator {
+    var childCoordinators = [Coordinator]()
+    let navigationController = UINavigationController()
+    var window: UIWindow?
+    var disposeBag = DisposeBag()
+    
+    init(window: UIWindow?) {
+        self.window = window
+    }
+    
+    func start() {
+        let networkManager = NetworkManager.shared
+        let appleLoginRepository = AppleLoginRepository(networkManager: networkManager)
+        let keychainProvider = KeychainProvider.shared
+        let loginReactor = LoginReactor(appleLoginRepository: appleLoginRepository, keychainProvider: keychainProvider)
+        let loginViewController = LoginViewController(reactor: loginReactor)
+        
+//        disposeBag.insert {
+//            loginReactor.state
+//                .distinctUntilChanged(\.isReadyToProceedWithSignUp)
+//                .withUnretained(self)
+//                .subscribe(onNext: { (owner, user) in
+//                    owner.pushSignUpAgreementViewController()
+//                })
+//        }
+//     
+
+        navigationController.setViewControllers([loginViewController], animated: false)
+        window?.rootViewController = navigationController
+        window?.makeKeyAndVisible()
+    }
+    private func pushSignUpAgreementViewController() {
+        let signUpAgreementReactor = SignUpAgreementReactor()
+        let signUpAgreementViewController = SignUpAgreementViewController(reactor: signUpAgreementReactor)
+        signUpAgreementReactor.state
+            .distinctUntilChanged(\.isReadyToProceedWithSignUp)
+            .map { $0.user }
+            .withUnretained(self)
+            .subscribe(onNext: { (this, user) in
+                this.pushSignUpProfileViewController(with: user)
+            })
+            .disposed(by: disposeBag)
+        
+        navigationController.pushViewController(signUpAgreementViewController, animated: true)
+    }
+    
+    private func pushSignUpProfileViewController(with user: UserAccount) {
+        let networkManager = NetworkManager.shared
+        let accountValidationRepository = AccountValidationRepository(networkManager: networkManager)
+        let keychain = KeychainQueryRequester()
+        let keychainProvider = KeychainProvider(keyChain: keychain)
+        let keychainUseCase = KeychainUsecase(keychainProvider: keychainProvider, networkManager: networkManager)
+        let regularExpressionValidator = RegularExpressionValidator()
+        let signUpProfileReactor = SignUpProfileReactor(user: user, regularExpressionValidator: regularExpressionValidator, accountValidationRepository: accountValidationRepository, keychainUseCase: keychainUseCase)
+        let signUpProfileViewController = SignUpProfileViewController(reactor: signUpProfileReactor)
+
+        signUpProfileReactor.state
+            .distinctUntilChanged(\.isReadyToProceedWithSignUp)
+            .map { $0.user }
+            .withUnretained(self)
+            .subscribe(onNext: { (this, user) in
+                this.pushSignUpInfomationViewController(with: user)
+            })
+            .disposed(by: disposeBag)
+        
+        navigationController.pushViewController(signUpProfileViewController, animated: true)
+    }
+    
+    private func pushSignUpInfomationViewController(with user: UserAccount) {
+        let signUpInfomationReactor = SignUpInfomationReactor(user: user)
+        let signUpInfomationViewController = SignUpInfomationViewController(reactor: signUpInfomationReactor)
+
+        signUpInfomationReactor.state
+            .distinctUntilChanged(\.isReadyToProceedWithSignUp)
+            .map { $0.user }
+            .withUnretained(self)
+            .subscribe(onNext: { (this, user) in
+                this.pushSignUpAreaViewController(with: user)
+            })
+            .disposed(by: disposeBag)
+        
+        navigationController.pushViewController(signUpInfomationViewController, animated: true)
+    }
+    
+    private func pushSignUpAreaViewController(with user: UserAccount) {
+        let networkManager = NetworkManager.shared
+        let signUpRepository = SignUpRepository(networkManager: networkManager)
+        let keychain = KeychainQueryRequester()
+        let keychainProvider = KeychainProvider(keyChain: keychain)
+        let keychainUseCase = KeychainUsecase(keychainProvider: keychainProvider, networkManager: networkManager)
+        let signUpAreaReactor = SignUpAreaReactor(user: user, keychainUseCase: keychainUseCase, signUpRepository: signUpRepository)
+        let signUpAreaViewController = SignUpAreaViewController(reactor: signUpAreaReactor)
+        
+        signUpAreaReactor.state
+            .distinctUntilChanged(\.isReadyToStartTogaether)
+            .withUnretained(self)
+            .subscribe(onNext: { (this, user) in
+                
+            })
+            .disposed(by: disposeBag)
+        
+        navigationController.pushViewController(signUpAreaViewController, animated: true)
+    }
+}

--- a/App/App/Sources/Common/Coordinator/AppCoordinator.swift
+++ b/App/App/Sources/Common/Coordinator/AppCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 final class AppCoordinator: Coordinator {
     private let window: UIWindow?
     var childCoordinators = [Coordinator]()
-    var isAlreadyLoggedIn = true
+    var isAlreadyLoggedIn = false
     
     init(window: UIWindow?) {
         self.window = window

--- a/App/App/Sources/Common/Coordinator/AuthCoordinator.swift
+++ b/App/App/Sources/Common/Coordinator/AuthCoordinator.swift
@@ -13,26 +13,16 @@ final class AuthCoordinator: Coordinator {
     private let window: UIWindow?
     var childCoordinators = [Coordinator]()
     var disposeBag = DisposeBag()
-    var isSimulator = true
 
     init(window: UIWindow?) {
         self.window = window
     }
     
     func start() {
-        if !isSimulator {
-            let loginCoordinator = LoginCoordinator()
-            childCoordinators.append(loginCoordinator)
-            loginCoordinator.start()
-            window?.rootViewController = loginCoordinator.navigationController
-        } else {
-            let navigationController = UINavigationController()
-            let SignUpAgreementCoordinator = SignUpAgreementCoordinator(navigationController: navigationController)
-            childCoordinators.append(SignUpAgreementCoordinator)
-            SignUpAgreementCoordinator.start()
-            window?.rootViewController = navigationController
-        }
-        
+        let loginCoordinator = LoginCoordinator()
+        childCoordinators.append(loginCoordinator)
+        loginCoordinator.start()
+        window?.rootViewController = loginCoordinator.navigationController
         window?.makeKeyAndVisible()
     }
 }

--- a/App/App/Sources/Scenes/AuthScene/LoginScene/LoginCoordinator.swift
+++ b/App/App/Sources/Scenes/AuthScene/LoginScene/LoginCoordinator.swift
@@ -26,16 +26,6 @@ final class LoginCoordinator: SceneCoordinator {
         let loginReactor = LoginReactor(appleLoginRepository: appleLoginRepository, keychainProvider: keychainProvider)
         let loginViewController = LoginViewController(reactor: loginReactor)
 
-        loginViewController.reactor?.state
-            .map(\.isReadyToProceedWithSignUp)
-            .distinctUntilChanged()
-            .filter { $0 == true }
-            .withUnretained(self)
-            .subscribe(onNext: { (owner, user) in
-                owner.pushSignUpAgreementViewController()
-            })
-            .disposed(by: disposeBag)
-        
         navigationController.setViewControllers([loginViewController], animated: false)
     }
     

--- a/App/App/Sources/Scenes/AuthScene/LoginScene/LoginViewController.swift
+++ b/App/App/Sources/Scenes/AuthScene/LoginScene/LoginViewController.swift
@@ -57,7 +57,18 @@ final class LoginViewController: BaseViewController {
     }
     
     private func bindState(with reactor: LoginReactor) {
-        
+        disposeBag.insert {
+            reactor.state
+                .map { $0.isReadyToProceedWithSignUp }
+                .filter { $0 == true }
+                .observe(on: MainScheduler.instance)
+                .subscribe(with: self,
+                   onNext: { this, isEnabled in
+                    let signUpAgreementReactor = SignUpAgreementReactor()
+                    let signUpAgreementViewController = SignUpAgreementViewController(reactor: signUpAgreementReactor)
+                    this.navigationController?.pushViewController(signUpAgreementViewController, animated: true)
+                })
+        }
     }
     
     func bind(reactor: LoginReactor) {

--- a/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpAreaReactor.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpAreaScene/SignUpAreaReactor.swift
@@ -21,9 +21,9 @@ final class SignUpAreaReactor: Reactor {
 
     enum Mutation {
         case showBigCities([String])
-        case updateBigCity(String?)
-        case showSmallCities([String]?)
-        case updateSmallCity(String?)
+        case updateBigCity(String)
+        case showSmallCities([String])
+        case updateSmallCity(String)
         case readyToStartTogaether
     }
 
@@ -32,7 +32,7 @@ final class SignUpAreaReactor: Reactor {
         var selectedBigCity: String?
         var selectedSmallCity: String?
         var bigCityList = Area.allCases.map { $0.rawValue }
-        var smallCityList: [String]?
+        var smallCityList = [String]()
         var isNextButtonEnabled = false
         var isReadyToStartTogaether = false
     }
@@ -54,12 +54,23 @@ final class SignUpAreaReactor: Reactor {
         case .bigCityTextFieldDidTap:
             return Observable.just(.showBigCities(currentState.bigCityList))
         case .bigCityDidPick(let city):
-            return Observable.just(.updateBigCity(currentState.bigCityList[safe: city]))
+            if let bigCity = currentState.bigCityList[safe: city] {
+                return Observable.just(.updateBigCity(bigCity))
+            } else {
+                return Observable.empty()
+            }
         case .smallCityTextFieldDidTap:
-            let smallCities = getSmallCities(bigCity: currentState.selectedBigCity)
-            return Observable.just(.showSmallCities(smallCities))
+            if let smallCities = getSmallCities(bigCity: currentState.selectedBigCity) {
+                return Observable.just(.showSmallCities(smallCities))
+            } else {
+                return Observable.empty()
+            }
         case .smallCityDidPick(let city):
-            return Observable.just(.updateSmallCity(currentState.smallCityList?[safe: city]))
+            if let smallCity = currentState.smallCityList[safe: city] {
+                return Observable.just(.updateSmallCity(smallCity))
+            } else {
+                return Observable.empty()
+            }
         case .nextButtonDidTap:
             return Observable.just(.readyToStartTogaether)
         }
@@ -77,6 +88,7 @@ final class SignUpAreaReactor: Reactor {
             if newState.selectedBigCity != state.selectedBigCity {
                 newState.user.smallCity = nil
                 newState.selectedSmallCity = nil
+                newState.smallCityList = []
                 newState.isNextButtonEnabled = false
             }
         case .showSmallCities(let cities):

--- a/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationViewController.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationViewController.swift
@@ -225,6 +225,23 @@ final class SignUpInfomationViewController: BaseViewController {
                         this.nextButton.becomeFirstResponder()
                     }
                 })
+            
+            reactor.state
+                .filter { $0.isReadyToProceedWithSignUp == true }
+                .map { $0.user }
+                .observe(on: MainScheduler.instance)
+                .subscribe(with: self,
+                   onNext: { this, user in
+                    let networkManager = NetworkManager.shared
+                    let signUpRepository = SignUpRepository(networkManager: networkManager)
+                    let keychain = KeychainQueryRequester()
+                    let keychainProvider = KeychainProvider(keyChain: keychain)
+                    let keychainUseCase = KeychainUsecase(keychainProvider: keychainProvider, networkManager: networkManager)
+                    let signUpAreaReactor = SignUpAreaReactor(user: user, keychainUseCase: keychainUseCase, signUpRepository: signUpRepository)
+                    let signUpAreaViewController = SignUpAreaViewController(reactor: signUpAreaReactor)
+
+                    this.navigationController?.pushViewController(signUpAreaViewController, animated: true)
+                })
         }
     }
     

--- a/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileViewController.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileViewController.swift
@@ -278,6 +278,18 @@ final class SignUpProfileViewController: BaseViewController {
                         this.nextButton.becomeFirstResponder()
                     }
                 })
+            
+            reactor.state
+                .filter { $0.isReadyToProceedWithSignUp == true }
+                .map { $0.user }
+                .observe(on: MainScheduler.instance)
+                .subscribe(with: self,
+                   onNext: { this, user in
+                    let signUpInfomationReactor = SignUpInfomationReactor(user: user)
+                    let signUpInfomationViewController = SignUpInfomationViewController(reactor: signUpInfomationReactor)
+
+                    this.navigationController?.pushViewController(signUpInfomationViewController, animated: true)
+                })
         }
     }
     


### PR DESCRIPTION
## 작업 내용 💾
- [ ] Coordinator 패턴 구현
- [ ] 활동 지역 소도시 선택 구현
- [ ] Auth 파이프라인 구성
     - 시뮬레이터에서는 마지막 화면까지 도달 가능
     - 마지막 화면에서 탭바로 넘어가는 기능 미구현
     
## 관련 이슈 🔗
x

## 리뷰어분들께 💚
Rx 사용하기 매우 어렵군요 ..ㅜ
skip, filter, distinctUntilChanged 등 구독 시점에 발생하는 이벤트를 자를만한 오퍼레이터를 써보곤 있는데 이벤트를 아직 잘 다루지는 못해서 Auth파이프라인의 마지막 화면에 있는 PickerView와 앱에서 사용하는 Coordinator에 문제가 있습니다.
이번 PR에선 코디네이터를 버릴까 고민하게됐네요 (꽤 오래 생각했는데 탭바까지 고려하니 제 능력이..)

+) 시뮬에서는 애플로그인 버튼을 눌러도 다음화면으로 넘어가지 않는데 원래 그런 것 같군여?
제가 잘못 구현한 걸수도 있음.

