### PR TITLE
[Fix] 공통 - 코디네이터 네비게이션 오류 수정 

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -631,6 +631,7 @@
 		378F3476281DBDB10063CE4F /* AuthScene */ = {
 			isa = PBXGroup;
 			children = (
+				37F67CC4286A1C270073FE8C /* AuthCoordinator.swift */,
 				3773708A2841DE4800D5CCB6 /* Entity */,
 				37605DED28394F4400394929 /* LoginScene */,
 				37605E02283C126100394929 /* SignUpAgreementScene */,
@@ -762,7 +763,6 @@
 			isa = PBXGroup;
 			children = (
 				37605DEB28394E0400394929 /* AppCoordinator.swift */,
-				37F67CC4286A1C270073FE8C /* AuthCoordinator.swift */,
 				37912CA528144A530087B95E /* TabCoordinator.swift */,
 				37912CA328144A260087B95E /* Protocol */,
 			);

--- a/App/App/Sources/Common/Repository/SignUpRepository.swift
+++ b/App/App/Sources/Common/Repository/SignUpRepository.swift
@@ -34,7 +34,7 @@ final class SignUpRepository: SignUpRepositoryInterface {
             urlRequest.httpBody = data
             urlRequest.httpMethod = HTTPMethod.post
             urlRequest.addValue(accessToken, forHTTPHeaderField: "Authorization")
-            urlRequest.addValue("multipart/form-data", forHTTPHeaderField: "Content-Type")
+            urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
             urlRequest.addValue("application/json", forHTTPHeaderField: "Accept")
             
             let response: Single<Int> = self.networkManager.requestDataTask(with: urlRequest)

--- a/App/App/Sources/Scenes/AuthScene/SignUpAgreementScene/SignUpAgreementReactor.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpAgreementScene/SignUpAgreementReactor.swift
@@ -26,9 +26,6 @@ final class SignUpAgreementReactor: Reactor {
         case togglePrivacyPolicy
         case syncAgreementWithTermsOfServiceAndPrivacyPolicy
         case syncTermsOfServiceAndPrivacyPolicyWithAgreement
-        case readyToProceedWithSignUp
-        case readyToShowTermsOfService
-        case readyToShowPrivacyPolicy
     }
     
     struct State {
@@ -36,12 +33,13 @@ final class SignUpAgreementReactor: Reactor {
         var isAgreementChecked = false
         var isTermsOfServiceChecked = false
         var isPrivacyPolicyChecked = false
-        var isReadyToProceedWithSignUp = false
-        var isReadyToShowTermsOfService = false
-        var isReadyToShowPrivacyPolicy = false
     }
     
     let initialState: State
+    
+    internal var readyToProceedWithSignUp = PublishSubject<UserAccount>()
+    internal var readyToShowTermsOfService = PublishSubject<Void>()
+    internal var readyToShowPrivacyPolicy = PublishSubject<Void>()
     
     init() {
         self.initialState = State()
@@ -59,17 +57,21 @@ final class SignUpAgreementReactor: Reactor {
                 Observable.just(.toggleTermsOfService),
                 Observable.just(.syncAgreementWithTermsOfServiceAndPrivacyPolicy)
             ])
-        case .termsOfServiceLabelDidTap:
-            return Observable.just(Mutation.readyToShowTermsOfService)
+            return Observable.empty()
         case .privacyPolicyCheckBoxDidTap:
             return Observable.concat([
                 Observable.just(.togglePrivacyPolicy),
                 Observable.just(.syncAgreementWithTermsOfServiceAndPrivacyPolicy)
             ])
+        case .termsOfServiceLabelDidTap:
+            readyToShowTermsOfService.onNext(())
+            return Observable.empty()
         case .privacyPolicyLabelDidTap:
-            return Observable.just(Mutation.readyToShowPrivacyPolicy)
+            readyToShowPrivacyPolicy.onNext(())
+            return Observable.empty()
         case .nextButtonDidTap:
-            return Observable.just(.readyToProceedWithSignUp)
+            readyToProceedWithSignUp.onNext((currentState.user))
+            return Observable.empty()
         }
     }
     
@@ -88,12 +90,6 @@ final class SignUpAgreementReactor: Reactor {
         case .syncTermsOfServiceAndPrivacyPolicyWithAgreement:
             newState.isTermsOfServiceChecked = newState.isAgreementChecked
             newState.isPrivacyPolicyChecked = newState.isAgreementChecked
-        case .readyToProceedWithSignUp:
-            newState.isReadyToProceedWithSignUp = true
-        case .readyToShowTermsOfService:
-            newState.isReadyToShowTermsOfService = true
-        case .readyToShowPrivacyPolicy:
-            newState.isReadyToShowPrivacyPolicy = true
         }
         
         return newState

--- a/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationReactor.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpInfomationScene/SignUpInfomationReactor.swift
@@ -24,7 +24,6 @@ final class SignUpInfomationReactor: Reactor {
         case selectMan
         case selectWoman
         case selectPrivateSex
-        case readyToProceedWithSignUp
     }
     
     struct State {
@@ -33,10 +32,11 @@ final class SignUpInfomationReactor: Reactor {
         var isWomanSelected = false
         var isPrivateSexSelected = false
         var isNextButtonEnabled = false
-        var isReadyToProceedWithSignUp = false
     }
     
     let initialState: State
+    
+    internal var readyToProceedWithSignUp = PublishSubject<UserAccount>()
     
     init(user: UserAccount) {
         initialState = State(user: user)
@@ -53,7 +53,8 @@ final class SignUpInfomationReactor: Reactor {
         case .privateSexButtonDidTap:
             return Observable.just(.selectPrivateSex)
         case .nextButtonDidTap:
-            return Observable.just(.readyToProceedWithSignUp)
+            readyToProceedWithSignUp.onNext(currentState.user)
+            return Observable.empty()
         }
     }
     
@@ -82,8 +83,6 @@ final class SignUpInfomationReactor: Reactor {
             newState.isWomanSelected = false
             newState.isPrivateSexSelected = true
             newState.isNextButtonEnabled = newState.user.age != nil && (newState.isManSelected || newState.isWomanSelected || newState.isPrivateSexSelected)
-        case .readyToProceedWithSignUp:
-            newState.isReadyToProceedWithSignUp = true
         }
         
         return newState

--- a/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileReactor.swift
+++ b/App/App/Sources/Scenes/AuthScene/SignUpProfileScene/SignUpProfileReactor.swift
@@ -23,7 +23,6 @@ final class SignUpProfileReactor: Reactor {
         case validateNicknameLength(Bool)
         case updateNickname(String)
         case checkNicknameDuplication(String?)
-        case readyToProceedWithSignUp
     }
     
     struct State {
@@ -31,7 +30,6 @@ final class SignUpProfileReactor: Reactor {
         var user: UserAccount
         var isNicknameValidationCheckDone = false
         var isNicknameDuplicateCheckDone = false
-        var isReadyToProceedWithSignUp = false
     }
     
     let initialState: State
@@ -40,6 +38,7 @@ final class SignUpProfileReactor: Reactor {
     private let accountValidationRepository: AccountValidationRepositoryInterface
     private let keychainUseCase: KeychainUseCaseInterface
     private let disposeBag = DisposeBag()
+    internal var readyToProceedWithSignUp = PublishSubject<UserAccount>()
     
     init(user: UserAccount, regularExpressionValidator: RegularExpressionValidatable, accountValidationRepository: AccountValidationRepositoryInterface, keychainUseCase: KeychainUseCaseInterface) {
         self.initialState = State(user: user)
@@ -59,7 +58,8 @@ final class SignUpProfileReactor: Reactor {
         case .duplicateCheckButtonDidTap:
             return checkDuplication(nickname: currentState.nickname)
         case .nextButtonDidTap:
-            return Observable.just(Mutation.readyToProceedWithSignUp)
+            readyToProceedWithSignUp.onNext(currentState.user)
+            return Observable.empty()
         }
     }
     
@@ -76,8 +76,6 @@ final class SignUpProfileReactor: Reactor {
             newState.isNicknameDuplicateCheckDone = (checkedNickname != nil)
         case .updateNickname(let nickname):
             newState.nickname = nickname
-        case .readyToProceedWithSignUp:
-            newState.isReadyToProceedWithSignUp = true
         }
         
         return newState


### PR DESCRIPTION
## 작업 내용 💾
- [x] push - pop 이후 push 할때 네비게이션 부적절한 버그 수정

## 관련 이슈 🔗
x

## 리뷰어분들께 💚
리액터킷의 State의 상태에 기반한 코디네이터 작동 시
currentState와 newState의 특정 프로퍼티가 동일하더라도
코디네이터가 State가 변경된 것으로 인식함
distinctUntilChanged를 사용하면 pop-repush할때 동작하지 않아서 곤란함

따라서 리액터킷의 State에 기반한 동작이 아니라
Reactor안, State밖에 화면전환 로직 트리거를 발동시키는 스트림을 둠.